### PR TITLE
Fix doctest option string processing

### DIFF
--- a/juliadoc/jldoctest.py
+++ b/juliadoc/jldoctest.py
@@ -10,6 +10,7 @@ import traceback
 import doctest
 from doctest import *
 from doctest import _SpoofOut, _indent, TestResults, _exception_traceback
+from doctest import OPTIONFLAGS_BY_NAME
 from subprocess import Popen, PIPE, STDOUT
 
 from docutils import nodes


### PR DESCRIPTION
Added an explicit from doctest import OPTIONFLAGS_BY_NAME. The presence of
option flags was causing exceptions because OPTIONFLAGS_BY_NAME was not
visible.
