### PR TITLE
add "document" class to content: fixes RTD search?

### DIFF
--- a/juliadoc/theme/julia/layout.html
+++ b/juliadoc/theme/julia/layout.html
@@ -115,7 +115,7 @@
       <div class="wy-nav-content">
         <div class="rst-content">
           {% include "breadcrumbs.html" %}
-          <div role="main">
+          <div role="main" class="document">
             {% block body %}{% endblock %}
           </div>
           {% include "footer.html" %}


### PR DESCRIPTION
Per @ihnorton in JuliaLang/julia#7134, following the convention mentioned in rtfd/readthedocs.org#225, adds the "document" class around the content we wish to index.
