### PR TITLE
RFC: Towards fixing on python3

### DIFF
--- a/juliadoc/jldoctest.py
+++ b/juliadoc/jldoctest.py
@@ -503,10 +503,9 @@ class SphinxDocTestRunner(object):
 
             # The example raised an exception:  check if it was expected.
             else:
-                exc_info = sys.exc_info()
-                exc_msg = traceback.format_exception_only(*exc_info[:2])[-1]
+                exc_msg = traceback.format_exception_only(*exception[:2])[-1]
                 if not quiet:
-                    got += _exception_traceback(exc_info)
+                    got += _exception_traceback(exception)
 
                 # If `example.exc_msg` is None, then we weren't expecting
                 # an exception.
@@ -536,7 +535,7 @@ class SphinxDocTestRunner(object):
             elif outcome is BOOM:
                 if not quiet:
                     self.report_unexpected_exception(out, test, example,
-                                                     exc_info)
+                                                     exception)
                 failures += 1
             else:
                 assert False, ("unknown outcome", outcome)

--- a/juliadoc/jldoctest.py
+++ b/juliadoc/jldoctest.py
@@ -466,19 +466,19 @@ class SphinxDocTestRunner(object):
             got = ""
             try:
                 # Don't blink!  This is where the user's code gets run.
-                src = example.source.strip().encode('utf-8').replace('"""',r'\"""')
+                src = example.source.strip().replace('"""',r'\"""')
                 # restore ans cleared by the separator println
-                self.julia.stdin.write('ans=_ans;')
+                self.julia.stdin.write('ans=_ans;'.encode('utf-8'))
                 # run command
                 show = 'true' if src[-1] != ';' else 'false'
                 cmd = 'Base.eval_user_input(Base.parse_input_line(raw""" ' \
                     + src + ' """),' + show + ');'
-                self.julia.stdin.write(cmd)
+                self.julia.stdin.write(cmd.encode('utf-8'))
                 # save ans, and make sure no more output is generated
-                self.julia.stdin.write('_ans=ans; nothing\n')
+                self.julia.stdin.write('_ans=ans; nothing\n'.encode('utf-8'))
                 # read separator
                 sep = 'fjsdiij3oi123j42'
-                self.julia.stdin.write('println("' + sep + '")\n')
+                self.julia.stdin.write(('println("' + sep + '")\n').encode('utf-8'))
                 got = []
                 line = ''
                 while line[:-1] != sep:
@@ -803,8 +803,8 @@ Doctest summary
     def test_group(self, group, filename):
 
         j = Popen(["../julia"], stdin=PIPE, stdout=PIPE, stderr=STDOUT)
-        j.stdin.write("macro raw_str(s) s end\n")
-        j.stdin.write("_ans = nothing\n")
+        j.stdin.write("macro raw_str(s) s end\n".encode('utf-8'))
+        j.stdin.write("_ans = nothing\n".encode('utf-8'))
         self.setup_runner.julia = j
         self.test_runner.julia = j
         self.cleanup_runner.julia = j

--- a/juliadoc/jldoctest.py
+++ b/juliadoc/jldoctest.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import re
 import sys
 import time

--- a/juliadoc/jldoctest.py
+++ b/juliadoc/jldoctest.py
@@ -479,6 +479,7 @@ class SphinxDocTestRunner(object):
                 # read separator
                 sep = 'fjsdiij3oi123j42'
                 self.julia.stdin.write(('println("' + sep + '")\n').encode('utf-8'))
+                self.julia.stdin.flush()
                 got = []
                 line = ''
                 while line[:-1] != sep:

--- a/juliadoc/jldoctest.py
+++ b/juliadoc/jldoctest.py
@@ -765,24 +765,24 @@ Doctest summary
                     groups[groupname] = TestGroup(groupname)
                 groups[groupname].add_code(code)
         for code in add_to_all_groups:
-            for group in groups.itervalues():
+            for group in groups.values():
                 group.add_code(code)
         if self.config.doctest_global_setup:
             code = TestCode(self.config.doctest_global_setup,
                             'testsetup', lineno=0)
-            for group in groups.itervalues():
+            for group in groups.values():
                 group.add_code(code, prepend=True)
         if self.config.doctest_global_cleanup:
             code = TestCode(self.config.doctest_global_cleanup,
                             'testcleanup', lineno=0)
-            for group in groups.itervalues():
+            for group in groups.values():
                 group.add_code(code)
         if not groups:
             return
 
         self._out('\nDocument: %s\n----------%s\n' %
                   (docname, '-'*len(docname)))
-        for group in groups.itervalues():
+        for group in groups.values():
             self.test_group(group, self.env.doc2path(docname, base=None))
         # Separately count results from setup code
         res_f, res_t = self.setup_runner.summarize(self._out, verbose=False)


### PR DESCRIPTION
As discussed with @tkelman at https://github.com/JuliaLang/julia/commit/354c730642346300c8eb5819b99e5d5e5aff729c#commitcomment-12483953

Everything here is safe to merge, I believe, as the doctests for julia still work under python2 after this pull request.  ~~But this PR does not fully fix things under python3: instead of erroring out under python3 (as before), the doctests seem to hang.  I have not yet gotten to the bottom of this.~~