### PR TITLE
Fix for macros without parameters

### DIFF
--- a/juliadoc/julia.py
+++ b/juliadoc/julia.py
@@ -6,10 +6,10 @@ import sphinx.domains.python
 
 sphinx.domains.python.py_sig_re = re.compile(
     r'''^ ([\w.]+\.)?            # class name(s)
-          ([^\s(]+)  \s*         # thing name
-          (?: \((.*)\)           # optional: arguments
-           (?:\s* -> \s* (.*))?  #           return annotation
-          )? $                   # and nothing more
+          ([^\s(]+)              # thing name
+          (?: \((.*?)\))?        # optional: arguments
+          (?:\s* -> \s* (.*))?   # optional: return annotation
+          $                      # and nothing more
           ''', re.VERBOSE | re.UNICODE)
 
 class JuliaDomain(sphinx.domains.python.PythonDomain):


### PR DESCRIPTION
Previously macros such as `@__FILE__` would [not have permalinks](http://julia.readthedocs.org/en/latest/stdlib/file/?highlight=__file__#Base.basename) since they did not include parenthesis. Not only was this annoying for cross-referencing but it made searching difficult as [searching for `@__FILE__`](http://julia.readthedocs.org/en/latest/search/?q=%40__FILE__) would result in no results.

Note however that parenthesis will automatically be added to macros without them in the rendered documentation. Ideally these would not be added.