### PR TITLE
Using the type directive no longer prepends "type"

### DIFF
--- a/juliadoc/julia.py
+++ b/juliadoc/julia.py
@@ -17,7 +17,7 @@ class JuliaDomain(sphinx.domains.python.PythonDomain):
     name = 'jl'
     label = 'Julia'
 
-JuliaDomain.directives['type'] = JuliaDomain.directives['class']
+JuliaDomain.directives['type'] = JuliaDomain.directives['function']
 
 def setup(app):
     app.add_domain(JuliaDomain)


### PR DESCRIPTION
Using the `type` directive in RST would prepend the word "type". For example: `.. type:: CompoundPeriod` rendered as `type CompoundPeriod` rather than just `CompoundPeriod`.